### PR TITLE
Allow modifiers to be int and string both

### DIFF
--- a/calver/collection_test.go
+++ b/calver/collection_test.go
@@ -115,6 +115,44 @@ func TestSortCollection(t *testing.T) {
 			versions: []string{"20240811", "20240711", "20250711", "20251130", "20250826"},
 			want:     []string{"20240711", "20240811", "20250711", "20250826", "20251130"},
 		},
+		{
+			name:     "7",
+			format:   "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			versions: []string{"20220721-alpha.1", "20210922-alpha.2", "20210318-alpha.3", "20260121-alpha.4", "20210721-alpha.5"},
+			want:     []string{"20210318-alpha.3", "20210721-alpha.5", "20210922-alpha.2", "20220721-alpha.1", "20260121-alpha.4"},
+		},
+		{
+			name:   "8",
+			format: "<YYYY>/<MM>/<DD>-eksbuild.<MODIFIER>",
+			versions: []string{
+				"2025/07/24-eksbuild.16002300",
+				"2025/07/24-eksbuild.16004300",
+				"2025/07/24-eksbuild.16001300",
+			},
+			want: []string{
+				"2025/07/24-eksbuild.16001300",
+				"2025/07/24-eksbuild.16002300",
+				"2025/07/24-eksbuild.16004300",
+			},
+		},
+		{
+			name:   "9",
+			format: "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			versions: []string{
+				"20250724-foobar.alpha",
+				"20250724-foobar.beta",
+				"20250724-foobar.gamma",
+				"20250724-foobar.delta",
+				"20250724-foobar.epsilon",
+			},
+			want: []string{
+				"20250724-foobar.alpha",
+				"20250724-foobar.beta",
+				"20250724-foobar.delta",
+				"20250724-foobar.epsilon",
+				"20250724-foobar.gamma",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/calver/compare.go
+++ b/calver/compare.go
@@ -32,10 +32,13 @@ func (c *CalVer) Compare(other *CalVer) (int, error) {
 
 	if c.Major != "" && other.Major != "" {
 		if c.Major != other.Major {
-			majorCurrent, _ := strconv.Atoi(c.Major)
-			majorOther, _ := strconv.Atoi(other.Major)
-			if majorCurrent == majorOther {
-				return 0, nil
+			majorCurrent, err := strconv.Atoi(c.Major)
+			if err != nil {
+				return 0, fmt.Errorf("major is not an integer: %s", c.Major)
+			}
+			majorOther, err := strconv.Atoi(other.Major)
+			if err != nil {
+				return 0, fmt.Errorf("major is not an integer: %s", other.Major)
 			}
 			if majorCurrent < majorOther {
 				return -1, nil
@@ -46,10 +49,13 @@ func (c *CalVer) Compare(other *CalVer) (int, error) {
 
 	if c.Minor != "" && other.Minor != "" {
 		if c.Minor != other.Minor {
-			minorCurrent, _ := strconv.Atoi(c.Minor)
-			minorOther, _ := strconv.Atoi(other.Minor)
-			if minorCurrent == minorOther {
-				return 0, nil
+			minorCurrent, err := strconv.Atoi(c.Minor)
+			if err != nil {
+				return 0, fmt.Errorf("minor is not an integer: %s", c.Minor)
+			}
+			minorOther, err := strconv.Atoi(other.Minor)
+			if err != nil {
+				return 0, fmt.Errorf("minor is not an integer: %s", other.Minor)
 			}
 			if minorCurrent < minorOther {
 				return -1, nil
@@ -60,10 +66,13 @@ func (c *CalVer) Compare(other *CalVer) (int, error) {
 
 	if c.Micro != "" && other.Micro != "" {
 		if c.Micro != other.Micro {
-			microCurrent, _ := strconv.Atoi(c.Micro)
-			microOther, _ := strconv.Atoi(other.Micro)
-			if microCurrent == microOther {
-				return 0, nil
+			microCurrent, err := strconv.Atoi(c.Micro)
+			if err != nil {
+				return 0, fmt.Errorf("micro is not an integer: %s", c.Micro)
+			}
+			microOther, err := strconv.Atoi(other.Micro)
+			if err != nil {
+				return 0, fmt.Errorf("micro is not an integer: %s", other.Micro)
 			}
 			if microCurrent < microOther {
 				return -1, nil
@@ -73,7 +82,15 @@ func (c *CalVer) Compare(other *CalVer) (int, error) {
 	}
 
 	if c.Modifier != "" && other.Modifier != "" {
-		return strings.Compare(c.Modifier, other.Modifier), nil
+		modifierCurrent, errModifierCurrent := strconv.Atoi(c.Modifier)
+		modifierOther, errModifierOther := strconv.Atoi(other.Modifier)
+		if errModifierCurrent != nil || errModifierOther != nil {
+			return strings.Compare(c.Modifier, other.Modifier), nil
+		}
+		if modifierCurrent < modifierOther {
+			return -1, nil
+		}
+		return 1, nil
 	}
 
 	return 0, nil

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -121,6 +121,27 @@ func TestCompare(t *testing.T) {
 			other:   "20250724",
 			want:    1,
 		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    1,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    -1,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    -1,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Updated the modifier comparison to be integer based on first priority if any of the modifiers are not integer they will be compared as strings.