### PR TITLE
Renamed some funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ import (
 
 func main() {
 	format := "Rel-<YYYY>-<0M>-<0D>"
-	// Create a new CalVer object
-	ver, err := calver.NewCalVer(format, "Rel-2025-07-14")
+	// Create a new Version object
+	ver, err := calver.NewVersion(format, "Rel-2025-07-14")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func main() {
 	fmt.Println(ver.String()) // Output: Rel-2025-07-14
 
 	// Compare with another version
-	other, _ := calver.NewCalVer(format, "Rel-2025-07-15")
+	other, _ := calver.NewVersion(format, "Rel-2025-07-15")
 	result, _ := ver.Compare(other)
 	fmt.Printf("Comparison result: %d\n", result) // Output: -1 (less than)
 }
@@ -109,19 +109,19 @@ Complete examples files can be found in the [examples](examples) dir
 
 ```go
 // Year-Month-Day format
-calver, err := calver.NewCalVer("<YYYY>-<MM>-<DD>", "2025-07-14")
+ver, err := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-14")
 if err != nil {
     log.Fatal(err)
 }
 
 // Year.Release format
-calver, err = calver.NewCalVer("<YYYY>.R<DD>", "2025.R14")
+ver, err = calver.NewVersion("<YYYY>.R<DD>", "2025.R14")
 if err != nil {
     log.Fatal(err)
 }
 
 // Ubuntu-style format
-calver, err = calver.NewCalVer("<0Y>.<0M>.<DD>", "22.04.6")
+ver, err = calver.NewVersion("<0Y>.<0M>.<DD>", "22.04.6")
 if err != nil {
     log.Fatal(err)
 }
@@ -130,21 +130,21 @@ if err != nil {
 ### Version Comparison
 
 ```go
-calver1, _ := calver.NewCalVer("<YYYY>-<MM>-<DD>", "2025-07-14")
-calver2, _ := calver.NewCalVer("<YYYY>-<MM>-<DD>", "2025-07-15")
+verA, _ := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-14")
+verB, _ := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-15")
 
-result, err := calver1.Compare(calver2)
+result, err := verA.Compare(verB)
 if err != nil {
     log.Fatal(err)
 }
 
 switch result {
 case -1:
-    fmt.Println("calver1 is older than calver2")
+    fmt.Println("verA is older than verB")
 case 0:
-    fmt.Println("calver1 equals calver2")
+    fmt.Println("verA equals verB")
 case 1:
-    fmt.Println("calver1 is newer than calver2")
+    fmt.Println("verA is newer than verB")
 }
 ```
 
@@ -175,7 +175,7 @@ for _, v := range collection {
 
 ```go
 // Create a version
-ver, err := calver.NewCalVer("<YYYY>.<0M>.<0D>", "2025.07.14")
+ver, err := calver.NewVersion("<YYYY>.<0M>.<0D>", "2025.07.14")
 if err != nil {
     log.Fatal(err)
 }
@@ -188,7 +188,7 @@ err = ver.IncMicro()   // 14 -> 15
 fmt.Println(ver.String()) // Output: 2026.08.15
 
 // Zero-padding is preserved
-ver, _ = calver.NewCalVer("<YYYY>.<0M>.<0D>", "2025.01.09")
+ver, _ = calver.NewVersion("<YYYY>.<0M>.<0D>", "2025.01.09")
 err = ver.IncMinor()   // 01 -> 02 (preserves zero-padding)
 err = ver.IncMicro()   // 09 -> 10 (loses zero-padding)
 
@@ -198,7 +198,7 @@ fmt.Println(ver.String()) // Output: 2025.02.10
 ### Series Management
 
 ```go
-ver, err := calver.NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+ver, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 if err != nil {
     log.Fatal(err)
 }
@@ -222,12 +222,12 @@ minorSeries := ver.Series("minor") // "Rel-2025-07"
 format := "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z"
 version := "RELEASE.2025-07-23T15-54-02Z"
 
-calver, err := calver.NewCalVer(format, version)
+ver, err := calver.NewVersion(format, version)
 if err != nil {
     log.Fatal(err)
 }
 
-fmt.Println(calver.String()) // Output: RELEASE.2025-07-23T15-54-02Z
+fmt.Println(ver.String()) // Output: RELEASE.2025-07-23T15-54-02Z
 ```
 
 ## Testing

--- a/calver/calver.go
+++ b/calver/calver.go
@@ -9,9 +9,9 @@ import (
 	"github.com/shazib-summar/go-calver/internal"
 )
 
-// CalVer is a CalVer object. To get the string representation of the version,
+// Version is a Version object. To get the string representation of the version,
 // use the String method.
-type CalVer struct {
+type Version struct {
 	// Format is the original format string.
 	Format string
 	// Major is the major version.
@@ -24,18 +24,18 @@ type CalVer struct {
 	Modifier string
 }
 
-// NewCalVer creates a new CalVer object from a format string and a version. The
-// format string is expected to follow the conventions defined in
+// NewVersion creates a new Version object from a format string and a version.
+// The format string is expected to follow the conventions defined in
 // ConventionsRegex.
 //
 // Example:
 //
-//	ver, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
-//		return err
+//	    return err
 //	}
 //	fmt.Println(ver.String()) // Rel-2025-07-14
-func NewCalVer(format string, version string) (*CalVer, error) {
+func NewVersion(format string, version string) (*Version, error) {
 	if !internal.ValidateFormat(format) {
 		return nil, fmt.Errorf("invalid format: %s", format)
 	}
@@ -57,7 +57,7 @@ func NewCalVer(format string, version string) (*CalVer, error) {
 		)
 	}
 
-	c := &CalVer{
+	c := &Version{
 		Format: originalFormat,
 	}
 	for i, lv := range re.SubexpNames() {
@@ -86,17 +86,17 @@ func NewCalVer(format string, version string) (*CalVer, error) {
 	return c, nil
 }
 
-// String returns the CalVer object as a string. The string will be in the
+// String returns the Version object as a string. The string will be in the
 // format of the original format string.
 //
 // Example:
 //
-//	calver, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
-//		return err
+//	    return err
 //	}
-//	fmt.Println(calver.String()) // Rel-2025-07-14
-func (c *CalVer) String() string {
+//	fmt.Println(ver.String()) // Rel-2025-07-14
+func (c *Version) String() string {
 	out := c.Format
 	versionParts := []string{c.Major, c.Minor, c.Micro, c.Modifier}
 	for i, lv := range internal.ValidLevels {
@@ -110,34 +110,34 @@ func (c *CalVer) String() string {
 }
 
 // GetMajor returns the major version.
-func (c *CalVer) GetMajor() string {
+func (c *Version) GetMajor() string {
 	return c.Major
 }
 
 // GetMinor returns the minor version.
-func (c *CalVer) GetMinor() string {
+func (c *Version) GetMinor() string {
 	return c.Minor
 }
 
 // GetMicro returns the micro version.
-func (c *CalVer) GetMicro() string {
+func (c *Version) GetMicro() string {
 	return c.Micro
 }
 
 // GetModifier returns the modifier version.
-func (c *CalVer) GetModifier() string {
+func (c *Version) GetModifier() string {
 	return c.Modifier
 }
 
 // GetFormat returns the original format string.
-func (c *CalVer) GetFormat() string {
+func (c *Version) GetFormat() string {
 	return c.Format
 }
 
 // IncMajor increments the major version. If the major version is 0 padded it
 // will retain the 0 padding unless the major version if of the form 09 or 099
 // or 0999 and so on.
-func (c *CalVer) IncMajor() error {
+func (c *Version) IncMajor() error {
 	major, err := internal.IncWithPadding(c.Major)
 	if err != nil {
 		return err
@@ -149,7 +149,7 @@ func (c *CalVer) IncMajor() error {
 // IncMinor increments the minor version. If the minor version is 0 padded it
 // will retain the 0 padding unless the minor version if of the form 09 or 099
 // or 0999 and so on.
-func (c *CalVer) IncMinor() error {
+func (c *Version) IncMinor() error {
 	minor, err := internal.IncWithPadding(c.Minor)
 	if err != nil {
 		return err
@@ -161,7 +161,7 @@ func (c *CalVer) IncMinor() error {
 // IncMicro increments the micro version. If the micro version is 0 padded it
 // will retain the 0 padding unless the micro version if of the form 09 or 099
 // or 0999 and so on.
-func (c *CalVer) IncMicro() error {
+func (c *Version) IncMicro() error {
 	micro, err := internal.IncWithPadding(c.Micro)
 	if err != nil {
 		return err
@@ -175,7 +175,7 @@ func (c *CalVer) IncMicro() error {
 // form 09 or 099 or 0999 and so on.
 //
 // Be careful with this. Only use if the modifier is a number.
-func (c *CalVer) IncModifier() error {
+func (c *Version) IncModifier() error {
 	modifier, err := internal.IncWithPadding(c.Modifier)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func (c *CalVer) IncModifier() error {
 	return nil
 }
 
-// Series returns the series of the CalVer object. The series determined using
+// Series returns the series of the Version object. The series determined using
 // the provided level. For example, if the level is major, the series will be
 // the major version. If the level is minor, the series will be the major and
 // minor version and so on.
@@ -194,16 +194,16 @@ func (c *CalVer) IncModifier() error {
 //
 // Example:
 //
-//	ver, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}
-//	fmt.Println(ver.Series("major")) // Rel-2025
-//	fmt.Println(ver.Series("minor")) // Rel-2025-07
-//	fmt.Println(ver.Series("micro")) // Rel-2025-07-14
+//	fmt.Println(ver.Series("major"))    // Rel-2025
+//	fmt.Println(ver.Series("minor"))    // Rel-2025-07
+//	fmt.Println(ver.Series("micro"))    // Rel-2025-07-14
 //	fmt.Println(ver.Series("modifier")) // Rel-2025-07-14-0
-//	fmt.Println(ver.Series("")) // Rel-2025-07-14
-func (c *CalVer) Series(level string) string {
+//	fmt.Println(ver.Series(""))         // Rel-2025-07-14
+func (c *Version) Series(level string) string {
 	level = strings.ToLower(level)
 	if !slices.Contains(internal.ValidLevels, level) {
 		return c.String()
@@ -238,7 +238,7 @@ func (c *CalVer) Series(level string) string {
 	return format
 }
 
-func getValueForLevel(c *CalVer, level string) string {
+func getValueForLevel(c *Version, level string) string {
 	if level == internal.KeyMajor {
 		return c.Major
 	}

--- a/calver/calver_test.go
+++ b/calver/calver_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewCalVer(t *testing.T) {
+func TestNewVersion(t *testing.T) {
 	tests := []struct {
 		name    string
 		format  string
@@ -35,7 +35,7 @@ func TestNewCalVer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := calver.NewCalVer(test.format, test.version)
+			_, err := calver.NewVersion(test.format, test.version)
 			if test.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -45,7 +45,7 @@ func TestNewCalVer(t *testing.T) {
 	}
 }
 
-func TestCalVerString(t *testing.T) {
+func TestVersionString(t *testing.T) {
 	tests := []struct {
 		name    string
 		format  string
@@ -77,14 +77,14 @@ func TestCalVerString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			calver, err := calver.NewCalVer(test.format, test.version)
+			calver, err := calver.NewVersion(test.format, test.version)
 			assert.NoError(t, err)
 			assert.Equal(t, test.want, calver.String())
 		})
 	}
 }
 
-func TestCalVerSeries(t *testing.T) {
+func TestVersionSeries(t *testing.T) {
 	tests := []struct {
 		name    string
 		format  string
@@ -108,7 +108,7 @@ func TestCalVerSeries(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			calver, err := calver.NewCalVer(test.format, test.version)
+			calver, err := calver.NewVersion(test.format, test.version)
 			assert.NoError(t, err)
 			assert.Equal(t, test.want, calver.Series(test.level))
 		})

--- a/calver/collection.go
+++ b/calver/collection.go
@@ -1,15 +1,15 @@
 package calver
 
-// Collection is a collection of CalVer objects. It implements the
+// Collection is a collection of Version objects. It implements the
 // sort.Interface interface.
-type Collection []*CalVer
+type Collection []*Version
 
 // NewCollection creates a new Collection from a format and a list of versions.
 // It returns an error if any of the versions do not match the format.
 func NewCollection(format string, versions ...string) (Collection, error) {
 	collection := make(Collection, len(versions))
 	for i, version := range versions {
-		calver, err := NewCalVer(format, version)
+		calver, err := NewVersion(format, version)
 		if err != nil {
 			return nil, err
 		}

--- a/calver/compare.go
+++ b/calver/compare.go
@@ -12,20 +12,20 @@ import (
 //
 // Example:
 //
-//	calver1, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}
-//	calver2, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+//	ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
 //	if err != nil {
 //	    return err
 //	}
-//	fmt.Printf("%d\n", calver1.Compare(calver2)) // -1
+//	fmt.Printf("%d\n", ver1.Compare(ver2)) // -1
 //
 // The comparison is done in the following order: major, minor, micro, modifier.
 // The major, minor and micro are compared as integers. The modifier is compared
 // as a string.
-func (c *CalVer) Compare(other *CalVer) (int, error) {
+func (c *Version) Compare(other *Version) (int, error) {
 	if c.Format != other.Format {
 		return 0, fmt.Errorf("formats do not match: %s and %s", c.Format, other.Format)
 	}
@@ -100,19 +100,19 @@ func (c *CalVer) Compare(other *CalVer) (int, error) {
 //
 // Example:
 //
-//	calver1, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}
-//	calver2, err := NewCalVer("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+//	ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
 //	if err != nil {
 //	    return err
 //	}
-//	fmt.Printf("%d\n", calver1.CompareOrPanic(calver2)) // -1
+//	fmt.Printf("%d\n", ver1.CompareOrPanic(ver2)) // -1
 //
 // This is useful when you are sure the comparison will succeed and do not want
 // an error return.
-func (c *CalVer) CompareOrPanic(other *CalVer) int {
+func (c *Version) CompareOrPanic(other *Version) int {
 	compare, err := c.Compare(other)
 	if err != nil {
 		panic(err)

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestCompare(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		format  string
@@ -146,11 +145,11 @@ func TestCompare(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			version, err := calver.NewCalVer(tt.format, tt.version)
+			ver, err := calver.NewVersion(tt.format, tt.version)
 			assert.NoError(t, err)
-			other, err := calver.NewCalVer(tt.format, tt.other)
+			other, err := calver.NewVersion(tt.format, tt.other)
 			assert.NoError(t, err)
-			got, err := version.Compare(other)
+			got, err := ver.Compare(other)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/examples/compare.go
+++ b/examples/compare.go
@@ -11,12 +11,12 @@ func ex_compare() {
 	versionA := "2025-Rel07/14"
 	versionB := "2025-Rel07/15"
 
-	verA, err := calver.NewCalVer(format, versionA)
+	verA, err := calver.NewVersion(format, versionA)
 	if err != nil {
 		panic(err)
 	}
 
-	verB, err := calver.NewCalVer(format, versionB)
+	verB, err := calver.NewVersion(format, versionB)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/newversion.go
+++ b/examples/newversion.go
@@ -6,7 +6,7 @@ import (
 	"github.com/shazib-summar/go-calver/calver"
 )
 
-func ex_newcalver() {
+func ex_newversion() {
 	entries := []map[string]string{
 		{
 			"format":  "Rel-<YYYY>-<0M>-<0D>",
@@ -31,7 +31,7 @@ func ex_newcalver() {
 	}
 
 	for _, entry := range entries {
-		ver, err := calver.NewCalVer(entry["format"], entry["version"])
+		ver, err := calver.NewVersion(entry["format"], entry["version"])
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
`calver.NewCalVer` was just odd, so was `calver.CalVer`. These are now renamed to `calver.NewVersion` and `calver.Version` as they read more natural.

This is a breaking change but no one use this library rn.