### PR TITLE
Add comparison helper functions and tests

### DIFF
--- a/calver/compare.go
+++ b/calver/compare.go
@@ -144,3 +144,100 @@ func (c *Version) Equal(other *Version) (bool, error) {
 	}
 	return compare == 0, nil
 }
+
+// EqualOrPanic is just Equal, but panics if there's an error.
+// // Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.EqualOrPanic(ver2)) // false
+func (c *Version) EqualOrPanic(other *Version) bool {
+	equal, err := c.Equal(other)
+	if err != nil {
+		panic(err)
+	}
+	return equal
+}
+
+// Less returns true if the current version is less than the other version.
+// If Compare() returns an error, Less will propagate it.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.Less(ver2)) // true
+func (c *Version) Less(other *Version) (bool, error) {
+	compare, err := c.Compare(other)
+	if err != nil {
+		return false, err
+	}
+	return compare == -1, nil
+}
+
+// LessOrPanic is just Less, but panics if there's an error.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.LessOrPanic(ver2)) // true
+func (c *Version) LessOrPanic(other *Version) bool {
+	less, err := c.Less(other)
+	if err != nil {
+		panic(err)
+	}
+	return less
+}
+
+// Greater returns true if the current version is greater than the other version.
+// If Compare() returns an error, Greater will propagate it.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.Greater(ver2)) // false
+func (c *Version) Greater(other *Version) (bool, error) {
+	compare, err := c.Compare(other)
+	if err != nil {
+		return false, err
+	}
+	return compare == 1, nil
+}
+
+// GreaterOrPanic is just Greater, but panics if there's an error.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.GreaterOrPanic(ver2)) // false
+func (c *Version) GreaterOrPanic(other *Version) bool {
+	greater, err := c.Greater(other)
+	if err != nil {
+		panic(err)
+	}
+	return greater
+}

--- a/calver/compare.go
+++ b/calver/compare.go
@@ -241,3 +241,83 @@ func (c *Version) GreaterOrPanic(other *Version) bool {
 	}
 	return greater
 }
+
+// LessOrEqual returns true if the current version is less than or equal to the other version.
+// If Compare() returns an error, LessOrEqual will propagate it.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.LessOrEqual(ver2)) // true
+func (c *Version) LessOrEqual(other *Version) (bool, error) {
+	compare, err := c.Compare(other)
+	if err != nil {
+		return false, err
+	}
+	return compare == -1 || compare == 0, nil
+}
+
+// LessOrEqualOrPanic is just LessOrEqual, but panics if there's an error.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.LessOrEqualOrPanic(ver2)) // true
+
+func (c *Version) LessOrEqualOrPanic(other *Version) bool {
+	lessOrEqual, err := c.LessOrEqual(other)
+	if err != nil {
+		panic(err)
+	}
+	return lessOrEqual
+}
+
+// GreaterOrEqual returns true if the current version is greater than or equal to the other version.
+// If Compare() returns an error, GreaterOrEqual will propagate it.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.GreaterOrEqual(ver2)) // false
+
+func (c *Version) GreaterOrEqual(other *Version) (bool, error) {
+	compare, err := c.Compare(other)
+	if err != nil {
+		return false, err
+	}
+	return compare == 1 || compare == 0, nil
+}
+
+// GreaterOrEqualOrPanic is just GreaterOrEqual, but panics if there's an error.
+// Example:
+// // ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// // if err != nil {
+// //     return err
+// // }
+// // ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+// // if err != nil {
+// //     return err
+// // }
+// // fmt.Printf("%t\n", ver1.GreaterOrEqualOrPanic(ver2)) // false
+func (c *Version) GreaterOrEqualOrPanic(other *Version) bool {
+	greaterOrEqual, err := c.GreaterOrEqual(other)
+	if err != nil {
+		panic(err)
+	}
+	return greaterOrEqual
+}

--- a/calver/compare.go
+++ b/calver/compare.go
@@ -119,3 +119,28 @@ func (c *Version) CompareOrPanic(other *Version) int {
 	}
 	return compare
 }
+
+// Equal returns true if the versions are equal, false otherwise.
+// If Compare() returns an error, Equal will propagate it.
+// Example:
+//
+// ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//
+//	if err != nil {
+//	    return err
+//	}
+//
+// ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+// if err != nil
+//
+//	    return err
+//	}
+//
+// fmt.Printf("%t\n", ver1.Equal(ver2)) // true
+func (c *Version) Equal(other *Version) (bool, error) {
+	compare, err := c.Compare(other)
+	if err != nil {
+		return false, err
+	}
+	return compare == 0, nil
+}

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -155,3 +155,151 @@ func TestCompare(t *testing.T) {
 		})
 	}
 }
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			got, err := ver.Equal(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -156,6 +156,219 @@ func TestCompare(t *testing.T) {
 	}
 }
 
+// All tests in which the function is expected to panic ignore the "want" field.
+func TestCompareOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    int
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    -1,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    -1,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    0,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    1,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    1,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    1,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    -1,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    -1,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    1,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    0,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    -1,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    -1,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    -1,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    -1,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    1,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    1,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    -1,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.CompareOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCompareOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.CompareOrPanic(other)
+		})
+	}
+}
+
 func TestEqual(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -300,6 +513,218 @@ func TestEqual(t *testing.T) {
 			got, err := ver.Equal(other)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEqualOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.EqualOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestEqualOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.EqualOrPanic(other)
 		})
 	}
 }

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -156,7 +156,6 @@ func TestCompare(t *testing.T) {
 	}
 }
 
-// All tests in which the function is expected to panic ignore the "want" field.
 func TestCompareOrPanicNonPanicking(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -878,6 +877,218 @@ func TestLess(t *testing.T) {
 	}
 }
 
+func TestLessOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    true,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    true,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    true,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    true,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    true,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    true,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.LessOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLessOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.LessOrPanic(other)
+		})
+	}
+}
+
 func TestGreater(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1023,6 +1234,218 @@ func TestGreater(t *testing.T) {
 			got, err := ver.Greater(other)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGreaterOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    true,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    true,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.GreaterOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGreaterOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.GreaterOrPanic(other)
 		})
 	}
 }
@@ -1176,6 +1599,218 @@ func TestGreaterOrEqual(t *testing.T) {
 	}
 }
 
+func TestGreaterOrEqualOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    true,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    true,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.GreaterOrEqualOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGreaterOrEqualOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.GreaterOrEqualOrPanic(other)
+		})
+	}
+}
+
 func TestLessOrEqual(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1321,6 +1956,218 @@ func TestLessOrEqual(t *testing.T) {
 			got, err := ver.LessOrEqual(other)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLessOrEqualOrPanicNonPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    true,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    true,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    true,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    true,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    true,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    true,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.Equal(t, nil, rec)
+			}()
+			got := ver.LessOrEqualOrPanic(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLessOrEqualOrPanicPanicking(t *testing.T) {
+	tests := []struct {
+		name    string
+		format1 string
+		format2 string
+		version string
+		other   string
+	}{
+		{
+			name:    "1",
+			format1: "<YYYY>-R<DD>",
+			format2: "<YYYY>-<MM>-<DD>",
+			version: "2025-R1",
+			other:   "2025-07-15",
+		},
+		{
+			name:    "2",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY>-WW<DD>",
+			version: "2025-07-14",
+			other:   "2025-WW15",
+		},
+		{
+			name:    "3",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "2025-07-14",
+			other:   "20250724-alpha.2",
+		},
+		{
+			name:    "4",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "2025-07-16",
+			other:   "20250724-eksbuild.16002300",
+		},
+		{
+			name:    "5",
+			format1: "<YYYY>-<MM>-<DD>",
+			format2: "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "2025-07-16",
+			other:   "RELEASE.2025-07-23T14-54-02Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format1, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format2, tt.other)
+			assert.NoError(t, err)
+			defer func() {
+				rec := recover()
+				assert.NotEqual(t, nil, rec)
+			}()
+			_ = ver.LessOrEqualOrPanic(other)
 		})
 	}
 }

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -303,3 +303,152 @@ func TestEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestLess(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    true,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    true,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    true,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    true,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    true,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    true,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			got, err := ver.Less(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/calver/compare_test.go
+++ b/calver/compare_test.go
@@ -452,3 +452,450 @@ func TestLess(t *testing.T) {
 		})
 	}
 }
+
+func TestGreater(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    true,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    true,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			got, err := ver.Greater(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGreaterOrEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    false,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    false,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    true,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    false,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    false,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    false,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    true,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    true,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    false,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			got, err := ver.GreaterOrEqual(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLessOrEqual(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		version string
+		other   string
+		want    bool
+	}{
+		{
+			name:    "1",
+			format:  "<YYYY>-R<DD>",
+			version: "2025-R1",
+			other:   "2025-R2",
+			want:    true,
+		},
+		{
+			name:    "2",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-15",
+			want:    true,
+		},
+		{
+			name:    "3",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-14",
+			other:   "2025-07-14",
+			want:    true,
+		},
+		{
+			name:    "4",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2025-07-14",
+			want:    false,
+		},
+		{
+			name:    "5",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "6",
+			format:  "<YYYY>-<MM>-<DD>",
+			version: "2025-07-16",
+			other:   "2020-07-14",
+			want:    false,
+		},
+		{
+			name:    "7",
+			format:  "<YYYY>.<MM>.<DD>",
+			version: "2020.06.16",
+			other:   "2020.07.14",
+			want:    true,
+		},
+		{
+			name:    "8",
+			format:  "<YYYY>-WW<DD>",
+			version: "2025-WW14",
+			other:   "2025-WW15",
+			want:    true,
+		},
+		{
+			name:    "9",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-22T15-54-02Z",
+			want:    false,
+		},
+		{
+			name:    "10",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "11",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T15-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-03Z",
+			want:    true,
+		},
+		{
+			name:    "12",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "13",
+			format:  "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z",
+			version: "RELEASE.2025-07-23T14-54-02Z",
+			other:   "RELEASE.2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "14",
+			format:  "<MAJOR>-<MINOR>-<MICRO>T<MODIFIER>Z",
+			version: "2025-07-23T14-54-02Z",
+			other:   "2025-07-23T15-54-02Z",
+			want:    true,
+		},
+		{
+			name:    "15",
+			format:  "<YYYY><MM><DD>",
+			version: "20260723",
+			other:   "20250724",
+			want:    false,
+		},
+		{
+			name:    "16",
+			format:  "<YYYY><MM><DD>-alpha.<MODIFIER>",
+			version: "20250724-alpha.2",
+			other:   "20250724-alpha.1",
+			want:    false,
+		},
+		{
+			name:    "17",
+			format:  "<YYYY><MM><DD>-eksbuild.<MODIFIER>",
+			version: "20250724-eksbuild.16002300",
+			other:   "20250724-eksbuild.16004300",
+			want:    true,
+		},
+		{
+			name:    "18",
+			format:  "<YYYY><MM><DD>-foobar.<MODIFIER>",
+			version: "20250724-foobar.alpha",
+			other:   "20250724-foobar.beta",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ver, err := calver.NewVersion(tt.format, tt.version)
+			assert.NoError(t, err)
+			other, err := calver.NewVersion(tt.format, tt.other)
+			assert.NoError(t, err)
+			got, err := ver.LessOrEqual(other)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This change adds `Equal()`, `Less()`, `Greater()`, `GreaterOrEqual()`, `LessOrEqual()`, and their variants `[X]OrPanic()` which panic instead of returning an error (all take two `Version`s as input.) It also adds tests for each function based on the tests already existing for Compare(). All tests given pass, including 5 for each `[X]OrPanic()` variant (which are non-exhaustive and just test for behavior when format does not match.)