### PR TITLE
Added ParseWithOptions and NewCollectionWithOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,5 @@ examples:
 	@go run examples/compare/main.go
 	@echo "\n--> examples/newversion ..\n"
 	@go run examples/newversion/main.go
+	@echo "\n--> examples/series ...\n"
+	@go run examples/series/main.go

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/shazib-summar/go-calver/calver"
+	"github.com/shazib-summar/go-calver"
 )
 
 func main() {
 	format := "Rel-<YYYY>-<0M>-<0D>"
 	// Create a new Version object
-	ver, err := calver.NewVersion(format, "Rel-2025-07-14")
+	ver, err := calver.Parse(format, "Rel-2025-07-14")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -62,8 +62,8 @@ func main() {
 	fmt.Println(ver.String()) // Output: Rel-2025-07-14
 
 	// Compare with another version
-	other, _ := calver.NewVersion(format, "Rel-2025-07-15")
-	result, _ := ver.Compare(other)
+	other, _ := calver.Parse(format, "Rel-2025-07-15")
+	result := ver.Compare(other)
 	fmt.Printf("Comparison result: %d\n", result) // Output: -1 (less than)
 }
 ```
@@ -109,19 +109,34 @@ Complete examples files can be found in the [examples](examples) dir
 
 ```go
 // Year-Month-Day format
-ver, err := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-14")
+ver, err := calver.Parse("<YYYY>-<MM>-<DD>", "2025-07-14")
 if err != nil {
     log.Fatal(err)
 }
 
 // Year.Release format
-ver, err = calver.NewVersion("<YYYY>.R<DD>", "2025.R14")
+ver, err = calver.Parse("<YYYY>.R<DD>", "2025.R14")
 if err != nil {
     log.Fatal(err)
 }
 
 // Ubuntu-style format
-ver, err = calver.NewVersion("<0Y>.<0M>.<DD>", "22.04.6")
+ver, err = calver.Parse("<0Y>.<0M>.<DD>", "22.04.6")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+### Version Creation with multiple Formats
+
+The following example shows how to create a Version object with multiple formats.
+In this case, the format that matches the version string will be used.
+
+```go
+ver, err := calver.ParseWithOptions(
+    "2025-07-14",
+    calver.WithFormat("<YYYY>-<MM>-<DD>", "<YYYY>.<MM>.<DD>"),
+)
 if err != nil {
     log.Fatal(err)
 }
@@ -130,14 +145,10 @@ if err != nil {
 ### Version Comparison
 
 ```go
-verA, _ := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-14")
-verB, _ := calver.NewVersion("<YYYY>-<MM>-<DD>", "2025-07-15")
+verA, _ := calver.Parse("<YYYY>-<MM>-<DD>", "2025-07-14")
+verB, _ := calver.Parse("<YYYY>.<MM>.<DD>", "2025.07.15")
 
-result, err := verA.Compare(verB)
-if err != nil {
-    log.Fatal(err)
-}
-
+result := verA.Compare(verB)
 switch result {
 case -1:
     fmt.Println("verA is older than verB")
@@ -171,11 +182,20 @@ for _, v := range collection {
 }
 ```
 
+### Working with Collections with multiple Formats
+
+```go
+collection, err := calver.NewCollectionWithOptions(
+    []string{"2025-07-14", "2025.07.15"},
+    calver.WithFormat("<YYYY>-<MM>-<DD>", "<YYYY>.<MM>.<DD>"),
+)
+```
+
 ### Version Incrementing
 
 ```go
 // Create a version
-ver, err := calver.NewVersion("<YYYY>.<0M>.<0D>", "2025.07.14")
+ver, err := calver.Parse("<YYYY>.<0M>.<0D>", "2025.07.14")
 if err != nil {
     log.Fatal(err)
 }
@@ -188,7 +208,7 @@ err = ver.IncMicro()   // 14 -> 15
 fmt.Println(ver.String()) // Output: 2026.08.15
 
 // Zero-padding is preserved
-ver, _ = calver.NewVersion("<YYYY>.<0M>.<0D>", "2025.01.09")
+ver, _ = calver.Parse("<YYYY>.<0M>.<0D>", "2025.01.09")
 err = ver.IncMinor()   // 01 -> 02 (preserves zero-padding)
 err = ver.IncMicro()   // 09 -> 10 (loses zero-padding)
 
@@ -198,7 +218,7 @@ fmt.Println(ver.String()) // Output: 2025.02.10
 ### Series Management
 
 ```go
-ver, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+ver, err := calver.Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 if err != nil {
     log.Fatal(err)
 }
@@ -222,7 +242,7 @@ minorSeries := ver.Series("minor") // "Rel-2025-07"
 format := "RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z"
 version := "RELEASE.2025-07-23T15-54-02Z"
 
-ver, err := calver.NewVersion(format, version)
+ver, err := calver.Parse(format, version)
 if err != nil {
     log.Fatal(err)
 }
@@ -256,7 +276,7 @@ changes, please open an issue first to discuss what you would like to change.
 3. Create a feature branch: `git checkout -b feature/amazing-feature`
 4. Make your changes and add tests
 5. Run tests: `go test ./...`
-6. Commit your changes: `git commit -m 'Add amazing feature'`
+6. Commit your changes with a DCO signature: `git commit -s -m 'Add amazing feature'`
 7. Push to the branch: `git push origin feature/amazing-feature`
 8. Open a Pull Request
 

--- a/calver.go
+++ b/calver.go
@@ -9,56 +9,169 @@ import (
 	"github.com/shazib-summar/go-calver/internal"
 )
 
-// Version is a Version object. To get the string representation of the version,
-// use the String method.
+// Version is the object representing a CalVer version. To get the string
+// representation of the Version, use the String method.
 type Version struct {
-	// Format is the original format string.
+	// Format is the original format string. If multiple formats were provided,
+	// this will be the format that matched the version string.
 	Format string
-	// Major is the major version.
+	// Major is the major version. This is guaranteed to be a number.
 	Major string
-	// Minor is the minor version.
+	// Minor is the minor version. This is guaranteed to be a number.
 	Minor string
-	// Micro is the micro version.
+	// Micro is the micro version. This is guaranteed to be a number.
 	Micro string
-	// Modifier is the modifier version.
+	// Modifier is the modifier version. This can be a number or a string.
 	Modifier string
 }
 
-// NewVersion creates a new Version object from a format string and a version.
-// The format string is expected to follow the conventions defined in
-// ConventionsRegex.
+type parseOptions struct {
+	formats []string
+}
+
+type parseOption func(*parseOptions)
+
+// WithFormat is a parse option that specifies the format string that should be
+// used to parse the version string.
 //
 // Example:
 //
-//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := ParseWithOptions("2025.07.14", WithFormat("<YYYY>.<0M>.<0D>"))
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(ver.String()) // 2025.07.14
+//
+// If there are more than one possible format that may match the version string,
+// this function can be used with the WithFormat option.
+//
+// Example:
+//
+//	formats := []string{
+//	    "<YYYY>.<0M>.<0D>",
+//	    "<YYYY>.<0M>.<0D>-<MODIFIER>",
+//	}
+//	ver, err := ParseWithOptions("2025.07.14", WithFormat(formats...))
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(ver.String()) // 2025.07.14
+//
+// If multiple formats are provided, the format that matches the version string
+// will be used. For example, in the following code, the format
+// `"Rel-<YYYY>-<0M>-<0D>"` will be used at it matches the version string while
+// the other formats do not.
+//
+//	ver, err := ParseWithOptions(
+//	    "Rel-2025-07-14",
+//	    WithFormat(
+//	        "Rel-<YYYY>",
+//	        "Rel-<YYYY>-<0M>",
+//	        "Rel-<YYYY>-<0M>-<0D>",
+//	    )
+//	)
 //	if err != nil {
 //	    return err
 //	}
 //	fmt.Println(ver.String()) // Rel-2025-07-14
-func NewVersion(format string, version string) (*Version, error) {
-	if !internal.ValidateFormat(format) {
-		return nil, fmt.Errorf("invalid format: %s", format)
+func WithFormat(formats ...string) parseOption {
+	return func(options *parseOptions) {
+		options.formats = formats
+	}
+}
+
+// Parse creates a new Version object from a format string and a version. The
+// format string is expected to follow the conventions defined in
+// ConventionsRegex.
+//
+// Example:
+//
+//	ver, err := Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(ver.String()) // Rel-2025-07-14
+//
+// This is the same as calling `ParseWithOptions(version, WithFormat(format))`
+func Parse(format string, version string) (*Version, error) {
+	return ParseWithOptions(version, WithFormat(format))
+}
+
+// ParseWithOptions creates a new Version object from a version string and a
+// list of parse options.
+//
+// Example:
+//
+//	ver, err := ParseWithOptions(
+//	    "Rel-2025-07-14",
+//	    WithFormat("Rel-<YYYY>-<0M>-<0D>"),
+//	)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(ver.String()) // Rel-2025-07-14
+//
+// If there are more than one possible format that may match the version string,
+// this function can be used with the WithFormat option.
+//
+// Example:
+//
+//	formats := []string{
+//	    "Rel-<YYYY>-<0M>-<0D>",
+//	    "<YYYY>.<0M>.<0D>",
+//	}
+//	ver, err := ParseWithOptions("Rel-2025-07-14", WithFormat(formats...))
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println(ver.String()) // Rel-2025-07-14
+func ParseWithOptions(version string, opts ...parseOption) (*Version, error) {
+	if len(opts) == 0 {
+		return nil, fmt.Errorf("at least one parseOption is required")
+	}
+	o := &parseOptions{}
+	for _, opt := range opts {
+		opt(o)
 	}
 
-	originalFormat := format
-	format = strings.ReplaceAll(format, ".", `\.`)
-	for _, con := range internal.ValidConventions {
-		format = strings.ReplaceAll(format, con, internal.ConventionsRegex[con])
+	if len(o.formats) == 0 {
+		return nil, fmt.Errorf("no format provided")
 	}
 
-	format = `^` + format + `$`
-	re := regexp.MustCompile(format)
-	groups := re.FindStringSubmatch(version)
+	var matchingFormat string
+	var re *regexp.Regexp
+	var groups []string
+	for _, f := range o.formats {
+		f_ := f // save a copy before modifying it
+		if !internal.ValidateFormat(f) {
+			return nil, fmt.Errorf("invalid format: %s", f)
+		}
+
+		f = strings.ReplaceAll(f, ".", `\.`)
+		for _, con := range internal.ValidConventions {
+			f = strings.ReplaceAll(f, con, internal.ConventionsRegex[con])
+		}
+
+		f = `^` + f + `$`
+		currRe := regexp.MustCompile(f)
+		currGroups := currRe.FindStringSubmatch(version)
+		if len(currGroups) > len(groups) {
+			matchingFormat = f_
+			re = currRe
+			groups = currGroups
+		}
+	}
+
 	if len(groups) == 0 {
 		return nil, fmt.Errorf(
-			"version %s does not match format: %s",
+			"version %q does not match any of the provided formats: %q",
 			version,
-			format,
+			strings.Join(o.formats, ", "),
 		)
 	}
 
 	c := &Version{
-		Format: originalFormat,
+		Format: matchingFormat,
 	}
 	for i, lv := range re.SubexpNames() {
 		if i == 0 {
@@ -91,7 +204,7 @@ func NewVersion(format string, version string) (*Version, error) {
 //
 // Example:
 //
-//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}
@@ -135,46 +248,37 @@ func (c *Version) GetFormat() string {
 }
 
 // IncMajor increments the major version. If the major version is 0 padded it
-// will retain the 0 padding unless the major version if of the form 09 or 099
+// will retain the 0 padding unless the major version is of the form 09 or 099
 // or 0999 and so on.
 func (c *Version) IncMajor() error {
-	major, err := internal.IncWithPadding(c.Major)
-	if err != nil {
-		return err
-	}
+	major, _ := internal.IncWithPadding(c.Major)
 	c.Major = major
 	return nil
 }
 
 // IncMinor increments the minor version. If the minor version is 0 padded it
-// will retain the 0 padding unless the minor version if of the form 09 or 099
+// will retain the 0 padding unless the minor version is of the form 09 or 099
 // or 0999 and so on.
 func (c *Version) IncMinor() error {
-	minor, err := internal.IncWithPadding(c.Minor)
-	if err != nil {
-		return err
-	}
+	minor, _ := internal.IncWithPadding(c.Minor)
 	c.Minor = minor
 	return nil
 }
 
 // IncMicro increments the micro version. If the micro version is 0 padded it
-// will retain the 0 padding unless the micro version if of the form 09 or 099
+// will retain the 0 padding unless the micro version is of the form 09 or 099
 // or 0999 and so on.
 func (c *Version) IncMicro() error {
-	micro, err := internal.IncWithPadding(c.Micro)
-	if err != nil {
-		return err
-	}
+	micro, _ := internal.IncWithPadding(c.Micro)
 	c.Micro = micro
 	return nil
 }
 
 // IncModifier increments the modifier version. If the modifier version is 0
-// padded it will retain the 0 padding unless the modifier version if of the
+// padded it will retain the 0 padding unless the modifier version is of the
 // form 09 or 099 or 0999 and so on.
 //
-// Be careful with this. Only use if the modifier is a number.
+// It will return an error if the modifier is not a number.
 func (c *Version) IncModifier() error {
 	modifier, err := internal.IncWithPadding(c.Modifier)
 	if err != nil {
@@ -194,7 +298,7 @@ func (c *Version) IncModifier() error {
 //
 // Example:
 //
-//	ver, err := NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver, err := Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}

--- a/collection.go
+++ b/collection.go
@@ -1,21 +1,32 @@
 package calver
 
+import "fmt"
+
 // Collection is a collection of Version objects. It implements the
 // sort.Interface interface.
 type Collection []*Version
 
-// NewCollection creates a new Collection from a format and a list of versions.
-// It returns an error if any of the versions do not match the format.
+// NewCollection creates a new Collection from a format string and a list of
+// versions. It will return an error if any of the versions do not match the
+// format.
+//
+// Example:
+//
+//	collection, err := calver.NewCollection(
+//	    "<YYYY>.<0M>.<0D>",
+//	    "2025.01.18",
+//	    "2023.07.14",
+//	    "2025.03.16",
+//	)
+//	if err != nil {
+//	    return err
+//	}
+//
+// This is the same as calling `NewCollectionWithOptions(versions,
+// WithFormat(format))`. Note that `WithFormat` option can take a list of
+// formats.
 func NewCollection(format string, versions ...string) (Collection, error) {
-	collection := make(Collection, len(versions))
-	for i, version := range versions {
-		calver, err := NewVersion(format, version)
-		if err != nil {
-			return nil, err
-		}
-		collection[i] = calver
-	}
-	return collection, nil
+	return NewCollectionWithOptions(versions, WithFormat(format))
 }
 
 func (c Collection) Len() int {
@@ -23,9 +34,63 @@ func (c Collection) Len() int {
 }
 
 func (c Collection) Less(i, j int) bool {
-	return c[i].CompareOrPanic(c[j]) < 0
+	return c[i].Compare(c[j]) < 0
 }
 
 func (c Collection) Swap(i, j int) {
 	c[i], c[j] = c[j], c[i]
+}
+
+// NewCollectionWithOptions creates a new `Collection` from a list of versions and
+// a list of parse options. It will return an error if any of the versions do
+// not match (any of) the format or if no options are provided.
+//
+// Example:
+//
+//	collection, err := calver.NewCollectionWithOptions(
+//	    []string{"2025.01.18", "2023.07.14", "2025.03.16"},
+//	    calver.WithFormat("<YYYY>.<0M>.<0D>"),
+//	)
+//	if err != nil {
+//	    return err
+//	}
+//
+// If there are more than one possible format that may match the version string,
+// this function can be used with the `WithFormat` option.
+//
+// Example:
+//
+//	formats := []string{
+//	    "<YYYY>.<0M>.<0D>",
+//	    "<YYYY>.<0M>.<0D>-<MODIFIER>",
+//	}
+//	collection, err := calver.NewCollectionWithOptions(
+//	    []string{"2025.01.18", "2023.07.14", "2025.03.16"},
+//	    calver.WithFormat(formats...),
+//	)
+//	if err != nil {
+//	    return err
+//	}
+func NewCollectionWithOptions(versions []string, opts ...parseOption) (Collection, error) {
+	if len(opts) == 0 {
+		return nil, fmt.Errorf("at least one parseOption is required")
+	}
+	o := &parseOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if len(o.formats) == 0 {
+		return nil, fmt.Errorf("no format provided")
+	}
+
+	collection := make(Collection, len(versions))
+	for i, version := range versions {
+		calver, err := ParseWithOptions(version, opts...)
+		if err != nil {
+			return nil, err
+		}
+		collection[i] = calver
+	}
+	return collection, nil
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -72,6 +72,82 @@ func TestNewCollection(t *testing.T) {
 	}
 }
 
+func TestNewCollectionWithOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   []string
+		versions []string
+		wantErr  bool
+	}{
+		{
+			name:     "1",
+			format:   []string{"<YYYY>-R<DD>", "<YYYY>-R<0D>"},
+			versions: []string{"2025-R1", "2025-R2", "2025-R3", "2025-R20", "2025-R35"},
+			wantErr:  false,
+		},
+		{
+			name:     "2",
+			format:   []string{"<YYYY>-<MM>-<DD>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"2025-07-14", "2025-07-15", "2025-07-16", "2025-07-17", "2025-07-18"},
+			wantErr:  false,
+		},
+		{
+			name:     "3",
+			format:   []string{"<YYYY>.<MM>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"2025.07.14", "2025.07.15", "2025.07.16", "2025.07.17", "2025.07.18"},
+			wantErr:  false,
+		},
+		{
+			name:     "4",
+			format:   []string{"<YYYY>-WW<DD>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"2025-WW14", "2025-WW15", "2025-WW16", "2025-WW17", "2025-WW18"},
+			wantErr:  false,
+		},
+		{
+			name:   "5",
+			format: []string{"RELEASE.<YYYY>-<0M>-<0D>T<MODIFIER>Z"},
+			versions: []string{
+				"RELEASE.2025-07-23T15-54-02Z",
+				"RELEASE.2025-07-23T15-54-03Z",
+				"RELEASE.2025-07-23T15-54-04Z",
+				"RELEASE.2025-07-23T15-54-05Z",
+				"RELEASE.2025-07-23T15-54-06Z",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "6",
+			format:   []string{"<YYYY><MM><DD>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"20250723", "20250724", "20250725", "20250726", "20250727"},
+			wantErr:  false,
+		},
+		{
+			name:     "7",
+			format:   []string{"<YYYY><MM><DD>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"20250723", "20250724", "20250725", "20250726", "20250727"},
+			wantErr:  false,
+		},
+		{
+			name:     "8",
+			format:   []string{"<YYYY>/<MM>/<DD>", "<YYYY>.<MM>.<DD>"},
+			versions: []string{"20250723", "20250724", "20250725", "20250726", "20250727"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collection, err := calver.NewCollectionWithOptions(tt.versions, calver.WithFormat(tt.format...))
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Greater(t, collection.Len(), 0)
+			}
+		})
+	}
+}
+
 func TestSortCollection(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/compare.go
+++ b/compare.go
@@ -1,121 +1,79 @@
 package calver
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
 
 // Compare returns 0 if the versions are equal, -1 if the current version is
 // less than the other version, and 1 if the current version is greater than the
-// other version. If the formats do not match, it returns an error.
+// other version.
 //
 // Example:
 //
-//	ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
+//	ver1, err := calver.Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
 //	if err != nil {
 //	    return err
 //	}
-//	ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
+//	ver2, err := calver.Parse("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
 //	if err != nil {
 //	    return err
 //	}
 //	fmt.Printf("%d\n", ver1.Compare(ver2)) // -1
 //
 // The comparison is done in the following order: major, minor, micro, modifier.
-// The major, minor and micro are compared as integers. The modifier is compared
-// as a string.
-func (c *Version) Compare(other *Version) (int, error) {
-	if c.Format != other.Format {
-		return 0, fmt.Errorf("formats do not match: %s and %s", c.Format, other.Format)
+// Major, minor and micro are compared as integers whereas the modifier is
+// compared as integer if it is a number otherwise as a string.
+func (c *Version) Compare(v *Version) int {
+	res := compareStringInt(c.Major, v.Major)
+	if res != 0 {
+		return res
 	}
 
-	if c.Major != "" && other.Major != "" {
-		if c.Major != other.Major {
-			majorCurrent, err := strconv.Atoi(c.Major)
-			if err != nil {
-				return 0, fmt.Errorf("major is not an integer: %s", c.Major)
-			}
-			majorOther, err := strconv.Atoi(other.Major)
-			if err != nil {
-				return 0, fmt.Errorf("major is not an integer: %s", other.Major)
-			}
-			if majorCurrent < majorOther {
-				return -1, nil
-			}
-			return 1, nil
-		}
+	res = compareStringInt(c.Minor, v.Minor)
+	if res != 0 {
+		return res
 	}
 
-	if c.Minor != "" && other.Minor != "" {
-		if c.Minor != other.Minor {
-			minorCurrent, err := strconv.Atoi(c.Minor)
-			if err != nil {
-				return 0, fmt.Errorf("minor is not an integer: %s", c.Minor)
-			}
-			minorOther, err := strconv.Atoi(other.Minor)
-			if err != nil {
-				return 0, fmt.Errorf("minor is not an integer: %s", other.Minor)
-			}
-			if minorCurrent < minorOther {
-				return -1, nil
-			}
-			return 1, nil
-		}
+	res = compareStringInt(c.Micro, v.Micro)
+	if res != 0 {
+		return res
 	}
 
-	if c.Micro != "" && other.Micro != "" {
-		if c.Micro != other.Micro {
-			microCurrent, err := strconv.Atoi(c.Micro)
-			if err != nil {
-				return 0, fmt.Errorf("micro is not an integer: %s", c.Micro)
-			}
-			microOther, err := strconv.Atoi(other.Micro)
-			if err != nil {
-				return 0, fmt.Errorf("micro is not an integer: %s", other.Micro)
-			}
-			if microCurrent < microOther {
-				return -1, nil
-			}
-			return 1, nil
-		}
+	res = compareStringInt(c.Modifier, v.Modifier)
+	if res != 0 {
+		return res
 	}
 
-	if c.Modifier != "" && other.Modifier != "" {
-		modifierCurrent, errModifierCurrent := strconv.Atoi(c.Modifier)
-		modifierOther, errModifierOther := strconv.Atoi(other.Modifier)
-		if errModifierCurrent != nil || errModifierOther != nil {
-			return strings.Compare(c.Modifier, other.Modifier), nil
-		}
-		if modifierCurrent < modifierOther {
-			return -1, nil
-		}
-		return 1, nil
-	}
-
-	return 0, nil
+	return 0
 }
 
-// CompareOrPanic is just Compare, but panics if there's an error.
-//
-// Example:
-//
-//	ver1, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-14")
-//	if err != nil {
-//	    return err
-//	}
-//	ver2, err := calver.NewVersion("Rel-<YYYY>-<0M>-<0D>", "Rel-2025-07-15")
-//	if err != nil {
-//	    return err
-//	}
-//	fmt.Printf("%d\n", ver1.CompareOrPanic(ver2)) // -1
-//
-// This is useful when you are sure the comparison will succeed and do not want
-// an error return.
-func (c *Version) CompareOrPanic(other *Version) int {
-	compare, err := c.Compare(other)
-	if err != nil {
-		panic(err)
+// compareStringInt compares two string integers as integers. It handles the
+// case where one or both of the strings are empty. If the integer in the first
+// string is larger it returns 1, if the integer in the second string is larger
+// it returns -1, and if they are equal it returns 0.
+func compareStringInt(a, b string) int {
+	if a == b {
+		return 0
 	}
-	return compare
+	if a == "" {
+		return -1
+	}
+	if b == "" {
+		return 1
+	}
+
+	aInt, errA := strconv.Atoi(a)
+	bInt, errB := strconv.Atoi(b)
+	if errA != nil || errB != nil {
+		return strings.Compare(a, b)
+	}
+
+	if aInt < bInt {
+		return -1
+	}
+	if aInt > bInt {
+		return 1
+	}
+	return 0
 }

--- a/compare_test.go
+++ b/compare_test.go
@@ -145,11 +145,11 @@ func TestCompare(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ver, err := calver.NewVersion(tt.format, tt.version)
+			ver, err := calver.Parse(tt.format, tt.version)
 			assert.NoError(t, err)
-			other, err := calver.NewVersion(tt.format, tt.other)
+			other, err := calver.Parse(tt.format, tt.other)
 			assert.NoError(t, err)
-			got, err := ver.Compare(other)
+			got := ver.Compare(other)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/examples/compare/main.go
+++ b/examples/compare/main.go
@@ -11,19 +11,19 @@ func main() {
 	versionA := "2025-Rel07/14"
 	versionB := "2025-Rel07/15"
 
-	verA, err := calver.NewVersion(format, versionA)
+	verA, err := calver.Parse(format, versionA)
 	if err != nil {
 		panic(err)
 	}
 
-	verB, err := calver.NewVersion(format, versionB)
+	verB, err := calver.Parse(format, versionB)
 	if err != nil {
 		panic(err)
 	}
 
-	if verA.CompareOrPanic(verB) == 0 {
+	if verA.Compare(verB) == 0 {
 		fmt.Println("Versions are equal")
-	} else if verA.CompareOrPanic(verB) > 0 {
+	} else if verA.Compare(verB) > 0 {
 		fmt.Println("Version A is greater than Version B")
 	} else {
 		fmt.Println("Version A is less than Version B")

--- a/examples/newversion/main.go
+++ b/examples/newversion/main.go
@@ -31,7 +31,7 @@ func main() {
 	}
 
 	for _, entry := range entries {
-		ver, err := calver.NewVersion(entry["format"], entry["version"])
+		ver, err := calver.Parse(entry["format"], entry["version"])
 		if err != nil {
 			panic(err)
 		}

--- a/examples/series/main.go
+++ b/examples/series/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/shazib-summar/go-calver"
+)
+
+func main() {
+	ver, err := calver.Parse(
+		"Rel-<YYYY>-<0M>-<0D>.<MODIFIER>",
+		"Rel-2025-07-14.alpha",
+	)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Version string: %s\n", ver.String())
+	fmt.Printf("Series (major): %s\n", ver.Series("major"))
+	fmt.Printf("Series (minor): %s\n", ver.Series("minor"))
+	fmt.Printf("Series (micro): %s\n", ver.Series("micro"))
+	fmt.Printf("Series (modifier): %s\n", ver.Series("modifier"))
+}


### PR DESCRIPTION
These funcs allow taking in a list of options that define the behavior of the function. Today there's only one option `WithFormat` that takes a list of formats.

For example, if we have the following versions:

```
2025-07-14
2025-07-15
```

We can obtain a Version object with the following code:

```go
ver, err := calver.ParseWithOptions(
    "2025-07-14",
    calver.WithFormat(
        "<YYYY>-<MM>-<DD>",
        "<YYYY>.<MM>.<DD>",
    ),
)
```

We can create a `Collection` with the following code:

```go
collection, err := calver.NewCollectionWithOptions(
    []string{"2025-07-14", "2025-07-15"},
    calver.WithFormat(
        "<YYYY>-<MM>-<DD>",
        "<YYYY>.<MM>.<DD>",
    ),
)
```

I also updated some funcs to remove some unnecessary error returns. For example the regex used to extract the version parts ensure the major, minor, and micro are numbers. This guarantee made the func simpler and remove the need for an error to be returned.

Also added more tests and updated documentation. Added an example for the `Series` method.

closes: https://github.com/shazib-summar/go-calver/issues/16
closes: https://github.com/shazib-summar/go-calver/issues/17